### PR TITLE
feat: langchain compatibility and simpler client instantiation

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -425,4 +425,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.3)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0"
-content-hash = "e277e7b32574327f8a4dddef9f6fe7f1660f0adff1bd0289442bb868bd8a840a"
+content-hash = "0be2b98b8f040ddb3f6766787d4a6ca6d0600c7b42cbebac0585a47fe6ce8757"

--- a/poetry.lock
+++ b/poetry.lock
@@ -176,62 +176,63 @@ protobuf = ["grpcio-tools (>=1.54.2)"]
 
 [[package]]
 name = "grpcio-tools"
-version = "1.54.2"
+version = "1.48.2"
 description = "Protobuf code generator for gRPC"
 category = "main"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.6"
 files = [
-    {file = "grpcio-tools-1.54.2.tar.gz", hash = "sha256:e11c2c2aee53f340992e8e4d6a59172cbbbd0193f1351de98c4f810a5041d5ca"},
-    {file = "grpcio_tools-1.54.2-cp310-cp310-linux_armv7l.whl", hash = "sha256:2b96f5f17d3156058be247fd25b062b4768138665694c00b056659618b8fb418"},
-    {file = "grpcio_tools-1.54.2-cp310-cp310-macosx_12_0_universal2.whl", hash = "sha256:11939c9a8a39bd4815c7e88cb2fee48e1948775b59dbb06de8fcae5991e84f9e"},
-    {file = "grpcio_tools-1.54.2-cp310-cp310-manylinux_2_17_aarch64.whl", hash = "sha256:129de5579f95d6a55dde185f188b4cbe19d1e2f1471425431d9930c31d300d70"},
-    {file = "grpcio_tools-1.54.2-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c4128c01cd6f5ea8f7c2db405dbfd8582cd967d36e6fa0952565436633b0e591"},
-    {file = "grpcio_tools-1.54.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e5c7292dd899ad8fa09a2be96719648cee37b17909fe8c12007e3bff58ebee61"},
-    {file = "grpcio_tools-1.54.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:5ef30c2dbc63c1e0a462423ca4f95001814d26ef4fe66208e53fcf220ea3b717"},
-    {file = "grpcio_tools-1.54.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:4abfc1892380abe6cef381eab86f9350cbd703bfe5d834095aa66fd91c886b6d"},
-    {file = "grpcio_tools-1.54.2-cp310-cp310-win32.whl", hash = "sha256:9acf443dcf6f68fbea3b7fb519e1716e014db1a561939f5aecc4abda74e4015d"},
-    {file = "grpcio_tools-1.54.2-cp310-cp310-win_amd64.whl", hash = "sha256:21b9d2dee80f3f77e4097252e7f0db89772335a7300b72ab3d2e5c280872b1db"},
-    {file = "grpcio_tools-1.54.2-cp311-cp311-linux_armv7l.whl", hash = "sha256:7b24fbab9e7598518ce4549e066df00aab79c2bf9bedcdde23fb5ef6a3cf532f"},
-    {file = "grpcio_tools-1.54.2-cp311-cp311-macosx_10_10_universal2.whl", hash = "sha256:7baa210c20f71a242d9ae0e02734628f6948e8bee3bf538647894af427d28800"},
-    {file = "grpcio_tools-1.54.2-cp311-cp311-manylinux_2_17_aarch64.whl", hash = "sha256:e3d0e5188ff8dbaddac2ee44731d36f09c4eccd3eac7328e547862c44f75cacd"},
-    {file = "grpcio_tools-1.54.2-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:27671c68c7e0e3c5ff9967f5500799f65a04e7b153b8ce10243c87c43199039d"},
-    {file = "grpcio_tools-1.54.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f39d8e8806b8857fb473ca6a9c7bd800b0673dfdb7283ff569af0345a222f32c"},
-    {file = "grpcio_tools-1.54.2-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:8e4c5a48f7b2e8798ce381498ee7b9a83c65b87ae66ee5022387394e5eb51771"},
-    {file = "grpcio_tools-1.54.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:4f285f8ef3de422717a36bd372239ae778b8cc112ce780ca3c7fe266dadc49fb"},
-    {file = "grpcio_tools-1.54.2-cp311-cp311-win32.whl", hash = "sha256:0f952c8a5c47e9204fe8959f7e9add149e660f6579d67cf65024c32736d34caf"},
-    {file = "grpcio_tools-1.54.2-cp311-cp311-win_amd64.whl", hash = "sha256:3237149beec39e897fd62cef4aa1e1cd9422d7a95661d24bd0a79200b167e730"},
-    {file = "grpcio_tools-1.54.2-cp37-cp37m-linux_armv7l.whl", hash = "sha256:0ab1b323905d449298523db5d34fa5bf5fffd645bd872b25598e2f8a01f0ea39"},
-    {file = "grpcio_tools-1.54.2-cp37-cp37m-macosx_10_10_universal2.whl", hash = "sha256:7d7e6e8d62967b3f037f952620cb7381cc39a4bd31790c75fcfba56cc975d70b"},
-    {file = "grpcio_tools-1.54.2-cp37-cp37m-manylinux_2_17_aarch64.whl", hash = "sha256:7f4624ef2e76a3a5313c4e61a81be38bcc16b59a68a85d30758b84cd2102b161"},
-    {file = "grpcio_tools-1.54.2-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e543f457935ba7b763b121f1bf893974393b4d30065042f947f85a8d81081b80"},
-    {file = "grpcio_tools-1.54.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0239b929eb8b3b30b2397eef3b9abb245087754d77c3721e3be43c44796de87d"},
-    {file = "grpcio_tools-1.54.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:0de05c7698c655e9a240dc34ae91d6017b93143ac89e5b20046d7ca3bd09c27c"},
-    {file = "grpcio_tools-1.54.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:a3ce0b98fb581c471424d2cda45120f57658ed97677c6fec4d6decf5d7c1b976"},
-    {file = "grpcio_tools-1.54.2-cp37-cp37m-win_amd64.whl", hash = "sha256:37393ef90674964175923afe3859fc5a208e1ece565f642b4f76a8c0224a0993"},
-    {file = "grpcio_tools-1.54.2-cp38-cp38-linux_armv7l.whl", hash = "sha256:8e4531267736d88fde1022b36dd42ed8163e3575bcbd12bfed96662872aa93fe"},
-    {file = "grpcio_tools-1.54.2-cp38-cp38-macosx_10_10_universal2.whl", hash = "sha256:a0b7049814442f918b522d66b1d015286afbeb9e6d141af54bbfafe31710a3c8"},
-    {file = "grpcio_tools-1.54.2-cp38-cp38-manylinux_2_17_aarch64.whl", hash = "sha256:b80585e06c4f0082327eb5c9ad96fbdb2b0e7c14971ea5099fe78c22f4608451"},
-    {file = "grpcio_tools-1.54.2-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:39fd530cfdf58dc05125775cc233b05554d553d27478f14ae5fd8a6306f0cb28"},
-    {file = "grpcio_tools-1.54.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3bb9ec4aea0f2b3006fb002fa59e5c10f92b48fc374619fbffd14d2b0e388c3e"},
-    {file = "grpcio_tools-1.54.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:d512de051342a576bb89777476d13c5266d9334cf4badb6468aed9dc8f5bdec1"},
-    {file = "grpcio_tools-1.54.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:1b8ee3099c51ce987fa8a08e6b93fc342b10228415dd96b5c0caa0387f636a6f"},
-    {file = "grpcio_tools-1.54.2-cp38-cp38-win32.whl", hash = "sha256:6037f123905dc0141f7c8383ca616ef0195e79cd3b4d82faaee789d4045e891b"},
-    {file = "grpcio_tools-1.54.2-cp38-cp38-win_amd64.whl", hash = "sha256:10dd41862f579d185c60f629b5ee89103e216f63b576079d258d974d980bad87"},
-    {file = "grpcio_tools-1.54.2-cp39-cp39-linux_armv7l.whl", hash = "sha256:f6787d07fdab31a32c433c1ba34883dea6559d8a3fbe08fb93d834ca34136b71"},
-    {file = "grpcio_tools-1.54.2-cp39-cp39-macosx_10_10_universal2.whl", hash = "sha256:21b1467e31e44429d2a78b50135c9cdbd4b8f6d3b5cd548bc98985d3bdc352d0"},
-    {file = "grpcio_tools-1.54.2-cp39-cp39-manylinux_2_17_aarch64.whl", hash = "sha256:30a49b8b168aced2a4ff40959e6c4383ad6cfd7a20839a47a215e9837eb722dc"},
-    {file = "grpcio_tools-1.54.2-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8742122782953d2fd038f0a199f047a24e941cc9718b1aac90876dbdb7167739"},
-    {file = "grpcio_tools-1.54.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:503ef1351c62fb1d6747eaf74932b609d8fdd4345b3591ef910adef8fa9969d0"},
-    {file = "grpcio_tools-1.54.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:72d15de4c4b6a764a76c4ae69d99c35f7a0751223688c3f7e62dfa95eb4f61be"},
-    {file = "grpcio_tools-1.54.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:df079479fb1b9e488334312e35ebbf30cbf5ecad6c56599f1a961800b33ab7c1"},
-    {file = "grpcio_tools-1.54.2-cp39-cp39-win32.whl", hash = "sha256:49c2846dcc4803476e839d8bd4db8845e928f19130e0ea86121f2d1f43d2b452"},
-    {file = "grpcio_tools-1.54.2-cp39-cp39-win_amd64.whl", hash = "sha256:b82ca472db9c914c44e39a41e9e8bd3ed724523dd7aff5ce37592b8d16920ed9"},
+    {file = "grpcio-tools-1.48.2.tar.gz", hash = "sha256:8902a035708555cddbd61b5467cea127484362decc52de03f061a1a520fe90cd"},
+    {file = "grpcio_tools-1.48.2-cp310-cp310-linux_armv7l.whl", hash = "sha256:92acc3e10ba2b0dcb90a88ae9fe1cc0ffba6868545207e4ff20ca95284f8e3c9"},
+    {file = "grpcio_tools-1.48.2-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:e5bb396d63495667d4df42e506eed9d74fc9a51c99c173c04395fe7604c848f1"},
+    {file = "grpcio_tools-1.48.2-cp310-cp310-manylinux_2_17_aarch64.whl", hash = "sha256:84a84d601a238572d049d3108e04fe4c206536e81076d56e623bd525a1b38def"},
+    {file = "grpcio_tools-1.48.2-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:70564521e86a0de35ea9ac6daecff10cb46860aec469af65869974807ce8e98b"},
+    {file = "grpcio_tools-1.48.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bdbbe63f6190187de5946891941629912ac8196701ed2253fa91624a397822ec"},
+    {file = "grpcio_tools-1.48.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:ae56f133b05b7e5d780ef7e032dd762adad7f3dc8f64adb43ff5bfabd659f435"},
+    {file = "grpcio_tools-1.48.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:f0feb4f2b777fa6377e977faa89c26359d4f31953de15e035505b92f41aa6906"},
+    {file = "grpcio_tools-1.48.2-cp310-cp310-win32.whl", hash = "sha256:80f450272316ca0924545f488c8492649ca3aeb7044d4bf59c426dcdee527f7c"},
+    {file = "grpcio_tools-1.48.2-cp310-cp310-win_amd64.whl", hash = "sha256:21ff50e321736eba22210bf9b94e05391a9ac345f26e7df16333dc75d63e74fb"},
+    {file = "grpcio_tools-1.48.2-cp36-cp36m-linux_armv7l.whl", hash = "sha256:d598ccde6338b2cfbb3124f34c95f03394209013f9b1ed4a5360a736853b1c27"},
+    {file = "grpcio_tools-1.48.2-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:a43d26714933f23de93ea0bf9c86c66a6ede709b8ca32e357f9e2181703e64ae"},
+    {file = "grpcio_tools-1.48.2-cp36-cp36m-manylinux_2_17_aarch64.whl", hash = "sha256:55fdebc73fb580717656b1bafa4f8eca448726a7aa22726a6c0a7895d2f0f088"},
+    {file = "grpcio_tools-1.48.2-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8588819b22d0de3aa1951e1991cc3e4b9aa105eecf6e3e24eb0a2fc8ab958b3e"},
+    {file = "grpcio_tools-1.48.2-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9771d4d317dca029dfaca7ec9282d8afe731c18bc536ece37fd39b8a974cc331"},
+    {file = "grpcio_tools-1.48.2-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:d886a9e052a038642b3af5d18e6f2085d1656d9788e202dc23258cf3a751e7ca"},
+    {file = "grpcio_tools-1.48.2-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:d77e8b1613876e0d8fd17709509d4ceba13492816426bd156f7e88a4c47e7158"},
+    {file = "grpcio_tools-1.48.2-cp36-cp36m-win32.whl", hash = "sha256:dcaaecdd5e847de5c1d533ea91522bf56c9e6b2dc98cdc0d45f0a1c26e846ea2"},
+    {file = "grpcio_tools-1.48.2-cp36-cp36m-win_amd64.whl", hash = "sha256:0119aabd9ceedfdf41b56b9fdc8284dd85a7f589d087f2694d743f346a368556"},
+    {file = "grpcio_tools-1.48.2-cp37-cp37m-linux_armv7l.whl", hash = "sha256:189be2a9b672300ca6845d94016bdacc052fdbe9d1ae9e85344425efae2ff8ef"},
+    {file = "grpcio_tools-1.48.2-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:9443f5c30bac449237c3cf99da125f8d6e6c01e17972bc683ee73b75dea95573"},
+    {file = "grpcio_tools-1.48.2-cp37-cp37m-manylinux_2_17_aarch64.whl", hash = "sha256:e0403e095b343431195db1305248b50019ad55d3dd310254431af87e14ef83a2"},
+    {file = "grpcio_tools-1.48.2-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5410d6b601d1404835e34466bd8aee37213489b36ee1aad2276366e265ff29d4"},
+    {file = "grpcio_tools-1.48.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51be91b7c7056ff9ee48b1eccd4a2840b0126230803a5e09dfc082a5b16a91c1"},
+    {file = "grpcio_tools-1.48.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:516eedd5eb7af6326050bc2cfceb3a977b9cc1144f283c43cc4956905285c912"},
+    {file = "grpcio_tools-1.48.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:d18599ab572b2f15a8f3db49503272d1bb4fcabb4b4d1214ef03aca1816b20a0"},
+    {file = "grpcio_tools-1.48.2-cp37-cp37m-win32.whl", hash = "sha256:d18ef2adc05a8ef9e58ac46357f6d4ce7e43e077c7eda0a4425773461f9d0e6e"},
+    {file = "grpcio_tools-1.48.2-cp37-cp37m-win_amd64.whl", hash = "sha256:6d9753944e5a6b6b78b76ce9d2ae0fe3f748008c1849deb7fadcb64489d6553b"},
+    {file = "grpcio_tools-1.48.2-cp38-cp38-linux_armv7l.whl", hash = "sha256:3c8749dca04a8d302862ceeb1dfbdd071ee13b281395975f24405a347e5baa57"},
+    {file = "grpcio_tools-1.48.2-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:7307dd2408b82ea545ae63502ec03036b025f449568556ea9a056e06129a7a4e"},
+    {file = "grpcio_tools-1.48.2-cp38-cp38-manylinux_2_17_aarch64.whl", hash = "sha256:072234859f6069dc43a6be8ad6b7d682f4ba1dc2e2db2ebf5c75f62eee0f6dfb"},
+    {file = "grpcio_tools-1.48.2-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6cc298fbfe584de8876a85355efbcf796dfbcfac5948c9560f5df82e79336e2a"},
+    {file = "grpcio_tools-1.48.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f75973a42c710999acd419968bc79f00327e03e855bbe82c6529e003e49af660"},
+    {file = "grpcio_tools-1.48.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:f766050e491d0b3203b6b85638015f543816a2eb7d089fc04e86e00f6de0e31d"},
+    {file = "grpcio_tools-1.48.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:8e0d74403484eb77e8df2566a64b8b0b484b5c87903678c381634dd72f252d5e"},
+    {file = "grpcio_tools-1.48.2-cp38-cp38-win32.whl", hash = "sha256:cb75bac0cd43858cb759ef103fe68f8c540cb58b63dda127e710228fec3007b8"},
+    {file = "grpcio_tools-1.48.2-cp38-cp38-win_amd64.whl", hash = "sha256:cabc8b0905cedbc3b2b7b2856334fa35cce3d4bc79ae241cacd8cca8940a5c85"},
+    {file = "grpcio_tools-1.48.2-cp39-cp39-linux_armv7l.whl", hash = "sha256:e712a6d00606ad19abdeae852a7e521d6f6d0dcea843708fecf3a38be16a851e"},
+    {file = "grpcio_tools-1.48.2-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:e7e7668f89fd598c5469bb58e16bfd12b511d9947ccc75aec94da31f62bc3758"},
+    {file = "grpcio_tools-1.48.2-cp39-cp39-manylinux_2_17_aarch64.whl", hash = "sha256:a415fbec67d4ff7efe88794cbe00cf548d0f0a5484cceffe0a0c89d47694c491"},
+    {file = "grpcio_tools-1.48.2-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d96e96ae7361aa51c9cd9c73b677b51f691f98df6086860fcc3c45852d96b0b0"},
+    {file = "grpcio_tools-1.48.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e20d7885a40e68a2bda92908acbabcdf3c14dd386c3845de73ba139e9df1f132"},
+    {file = "grpcio_tools-1.48.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:8a5614251c46da07549e24f417cf989710250385e9d80deeafc53a0ee7df6325"},
+    {file = "grpcio_tools-1.48.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:ace0035766fe01a1b096aa050be9f0a9f98402317e7aeff8bfe55349be32a407"},
+    {file = "grpcio_tools-1.48.2-cp39-cp39-win32.whl", hash = "sha256:4fa4300b1be59b046492ed3c5fdb59760bc6433f44c08f50de900f9552ec7461"},
+    {file = "grpcio_tools-1.48.2-cp39-cp39-win_amd64.whl", hash = "sha256:0fb6c1c1e56eb26b224adc028a4204b6ad0f8b292efa28067dff273bbc8b27c4"},
 ]
 
 [package.dependencies]
-grpcio = ">=1.54.2"
-protobuf = ">=4.21.6,<5.0dev"
+grpcio = ">=1.48.2"
+protobuf = ">=3.12.0,<4.0dev"
 setuptools = "*"
 
 [[package]]
@@ -301,25 +302,34 @@ virtualenv = ">=20.10.0"
 
 [[package]]
 name = "protobuf"
-version = "4.23.2"
-description = ""
+version = "3.20.3"
+description = "Protocol Buffers"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "protobuf-4.23.2-cp310-abi3-win32.whl", hash = "sha256:384dd44cb4c43f2ccddd3645389a23ae61aeb8cfa15ca3a0f60e7c3ea09b28b3"},
-    {file = "protobuf-4.23.2-cp310-abi3-win_amd64.whl", hash = "sha256:09310bce43353b46d73ba7e3bca78273b9bc50349509b9698e64d288c6372c2a"},
-    {file = "protobuf-4.23.2-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:b2cfab63a230b39ae603834718db74ac11e52bccaaf19bf20f5cce1a84cf76df"},
-    {file = "protobuf-4.23.2-cp37-abi3-manylinux2014_aarch64.whl", hash = "sha256:c52cfcbfba8eb791255edd675c1fe6056f723bf832fa67f0442218f8817c076e"},
-    {file = "protobuf-4.23.2-cp37-abi3-manylinux2014_x86_64.whl", hash = "sha256:86df87016d290143c7ce3be3ad52d055714ebaebb57cc659c387e76cfacd81aa"},
-    {file = "protobuf-4.23.2-cp37-cp37m-win32.whl", hash = "sha256:281342ea5eb631c86697e1e048cb7e73b8a4e85f3299a128c116f05f5c668f8f"},
-    {file = "protobuf-4.23.2-cp37-cp37m-win_amd64.whl", hash = "sha256:ce744938406de1e64b91410f473736e815f28c3b71201302612a68bf01517fea"},
-    {file = "protobuf-4.23.2-cp38-cp38-win32.whl", hash = "sha256:6c081863c379bb1741be8f8193e893511312b1d7329b4a75445d1ea9955be69e"},
-    {file = "protobuf-4.23.2-cp38-cp38-win_amd64.whl", hash = "sha256:25e3370eda26469b58b602e29dff069cfaae8eaa0ef4550039cc5ef8dc004511"},
-    {file = "protobuf-4.23.2-cp39-cp39-win32.whl", hash = "sha256:efabbbbac1ab519a514579ba9ec52f006c28ae19d97915951f69fa70da2c9e91"},
-    {file = "protobuf-4.23.2-cp39-cp39-win_amd64.whl", hash = "sha256:54a533b971288af3b9926e53850c7eb186886c0c84e61daa8444385a4720297f"},
-    {file = "protobuf-4.23.2-py3-none-any.whl", hash = "sha256:8da6070310d634c99c0db7df48f10da495cc283fd9e9234877f0cd182d43ab7f"},
-    {file = "protobuf-4.23.2.tar.gz", hash = "sha256:20874e7ca4436f683b64ebdbee2129a5a2c301579a67d1a7dda2cdf62fb7f5f7"},
+    {file = "protobuf-3.20.3-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:f4bd856d702e5b0d96a00ec6b307b0f51c1982c2bf9c0052cf9019e9a544ba99"},
+    {file = "protobuf-3.20.3-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:9aae4406ea63d825636cc11ffb34ad3379335803216ee3a856787bcf5ccc751e"},
+    {file = "protobuf-3.20.3-cp310-cp310-win32.whl", hash = "sha256:28545383d61f55b57cf4df63eebd9827754fd2dc25f80c5253f9184235db242c"},
+    {file = "protobuf-3.20.3-cp310-cp310-win_amd64.whl", hash = "sha256:67a3598f0a2dcbc58d02dd1928544e7d88f764b47d4a286202913f0b2801c2e7"},
+    {file = "protobuf-3.20.3-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:899dc660cd599d7352d6f10d83c95df430a38b410c1b66b407a6b29265d66469"},
+    {file = "protobuf-3.20.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e64857f395505ebf3d2569935506ae0dfc4a15cb80dc25261176c784662cdcc4"},
+    {file = "protobuf-3.20.3-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:d9e4432ff660d67d775c66ac42a67cf2453c27cb4d738fc22cb53b5d84c135d4"},
+    {file = "protobuf-3.20.3-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:74480f79a023f90dc6e18febbf7b8bac7508420f2006fabd512013c0c238f454"},
+    {file = "protobuf-3.20.3-cp37-cp37m-win32.whl", hash = "sha256:b6cc7ba72a8850621bfec987cb72623e703b7fe2b9127a161ce61e61558ad905"},
+    {file = "protobuf-3.20.3-cp37-cp37m-win_amd64.whl", hash = "sha256:8c0c984a1b8fef4086329ff8dd19ac77576b384079247c770f29cc8ce3afa06c"},
+    {file = "protobuf-3.20.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:de78575669dddf6099a8a0f46a27e82a1783c557ccc38ee620ed8cc96d3be7d7"},
+    {file = "protobuf-3.20.3-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:f4c42102bc82a51108e449cbb32b19b180022941c727bac0cfd50170341f16ee"},
+    {file = "protobuf-3.20.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:44246bab5dd4b7fbd3c0c80b6f16686808fab0e4aca819ade6e8d294a29c7050"},
+    {file = "protobuf-3.20.3-cp38-cp38-win32.whl", hash = "sha256:c02ce36ec760252242a33967d51c289fd0e1c0e6e5cc9397e2279177716add86"},
+    {file = "protobuf-3.20.3-cp38-cp38-win_amd64.whl", hash = "sha256:447d43819997825d4e71bf5769d869b968ce96848b6479397e29fc24c4a5dfe9"},
+    {file = "protobuf-3.20.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:398a9e0c3eaceb34ec1aee71894ca3299605fa8e761544934378bbc6c97de23b"},
+    {file = "protobuf-3.20.3-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:bf01b5720be110540be4286e791db73f84a2b721072a3711efff6c324cdf074b"},
+    {file = "protobuf-3.20.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:daa564862dd0d39c00f8086f88700fdbe8bc717e993a21e90711acfed02f2402"},
+    {file = "protobuf-3.20.3-cp39-cp39-win32.whl", hash = "sha256:819559cafa1a373b7096a482b504ae8a857c89593cf3a25af743ac9ecbd23480"},
+    {file = "protobuf-3.20.3-cp39-cp39-win_amd64.whl", hash = "sha256:03038ac1cfbc41aa21f6afcbcd357281d7521b4157926f30ebecc8d4ea59dcb7"},
+    {file = "protobuf-3.20.3-py2.py3-none-any.whl", hash = "sha256:a7ca6d488aa8ff7f329d4c545b2dbad8ac31464f1d8b1c87ad1346717731e4db"},
+    {file = "protobuf-3.20.3.tar.gz", hash = "sha256:2e3427429c9cffebf259491be0af70189607f365c2f41c7c3764af6f337105f2"},
 ]
 
 [[package]]
@@ -425,4 +435,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.3)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0"
-content-hash = "0be2b98b8f040ddb3f6766787d4a6ca6d0600c7b42cbebac0585a47fe6ce8757"
+content-hash = "4793aa535f13021680e8046482e44deb5490f99f95baf5ebf68b5c82cf3b51b6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ include = ["api/generated/**/*"]
 
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"
-protobuf = "^4.22.3"
+protobuf = ">=3.18.3"
 grpcio-tools = ">=1.46.0"
 
 [tool.poetry.group.dev]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ include = ["api/generated/**/*"]
 
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"
-protobuf = ">=3.18.3"
+protobuf = ">=3.19.6"
 grpcio-tools = ">=1.46.0"
 
 [tool.poetry.group.dev]

--- a/scripts/proto.py
+++ b/scripts/proto.py
@@ -40,8 +40,8 @@ def generate():
     for proto_file in proto_sources:
         cmd_run(
             f"python -m grpc_tools.protoc --proto_path={PROTO_ROOT}"
-            f" --python_out={GENERATED_PROTO_DIR} --pyi_out={GENERATED_PROTO_DIR} "
-            f"--grpc_python_out={GENERATED_PROTO_DIR} {proto_file}",
+            f" --python_out={GENERATED_PROTO_DIR}"
+            f" --grpc_python_out={GENERATED_PROTO_DIR} {proto_file}",
             shell=True,
             check=True,
         )

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -21,9 +21,7 @@ from tigrisdb.utils import obj_to_b64
 class AuthGatewayTest(TestCase):
     def setUp(self) -> None:
         self.done_future = MagicMock(grpc.Future)
-        self.client_config = ClientConfig(
-            server_url="localhost:5000", project_name="db1"
-        )
+        self.client_config = ClientConfig(server_url="localhost:5000", project="db1")
 
     def test_get_access_token_with_valid_token_refresh_window(
         self, channel_ready_future, grpc_auth

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -34,32 +34,8 @@ class TigrisClientTest(TestCase):
         self.assertEqual("uri:443", client.config.server_url)
         self.assertEqual("client", client.config.client_id)
         self.assertEqual("secret", client.config.client_secret)
-        self.assertEqual("project", client.config.project_name)
+        self.assertEqual("project", client.config.project)
         self.assertEqual("branch", client.config.branch)
-
-    def test_init_with_dict_missing_client_id(self, ready_future):
-        ready_future.return_value = self.done_future
-        with self.assertRaisesRegex(
-            ValueError, "`TIGRIS_CLIENT_ID` environment variable"
-        ):
-            TigrisClient(
-                {
-                    "project": "project",
-                    "client_secret": "secret",
-                }
-            )
-
-    def test_init_with_dict_missing_client_secret(self, ready_future):
-        ready_future.return_value = self.done_future
-        with self.assertRaisesRegex(
-            ValueError, "`TIGRIS_CLIENT_SECRET` environment variable"
-        ):
-            TigrisClient(
-                {
-                    "project": "project",
-                    "client_id": "id",
-                }
-            )
 
     @patch.dict(
         os.environ,
@@ -72,14 +48,14 @@ class TigrisClientTest(TestCase):
         ready_future.return_value = self.done_future
         client = TigrisClient({"project": "p1"})
         self.assertEqual("localhost:5000", client.config.server_url)
-        self.assertEqual("p1", client.config.project_name)
+        self.assertEqual("p1", client.config.project)
 
     def test_init_with_config(self, ready_future):
         ready_future.return_value = self.done_future
         client = TigrisClient(
             conf=ClientConfig(
                 server_url="test_url",
-                project_name="test_project",
+                project="test_project",
                 client_id="test_client_id",
                 client_secret="test_client_secret",
                 branch="test_branch",
@@ -88,7 +64,7 @@ class TigrisClientTest(TestCase):
         self.assertEqual("test_url:443", client.config.server_url)
         self.assertEqual("test_client_id", client.config.client_id)
         self.assertEqual("test_client_secret", client.config.client_secret)
-        self.assertEqual("test_project", client.config.project_name)
+        self.assertEqual("test_project", client.config.project)
         self.assertEqual("test_branch", client.config.branch)
 
     def test_init_local_dev(self, ready_future):
@@ -97,7 +73,7 @@ class TigrisClientTest(TestCase):
             {"server_url": "localhost:5000", "project": "test_project"}
         )
         self.assertEqual("localhost:5000", client.config.server_url)
-        self.assertEqual("test_project", client.config.project_name)
+        self.assertEqual("test_project", client.config.project)
 
     def test_init_failing_validation(self, ready_future):
         ready_future.return_value = self.done_future
@@ -122,14 +98,14 @@ class TigrisClientTest(TestCase):
         self.assertEqual("uri_env:443", client.config.server_url)
         self.assertEqual("client_env", client.config.client_id)
         self.assertEqual("secret_env", client.config.client_secret)
-        self.assertEqual("project_env", client.config.project_name)
+        self.assertEqual("project_env", client.config.project)
         self.assertEqual("branch_env", client.config.branch)
 
     def test_strip_https(self, ready_future):
         ready_future.return_value = self.done_future
         conf = ClientConfig(
             server_url="https://my.tigris.dev",
-            project_name="p1",
+            project="p1",
             client_id="id",
             client_secret="secret",
         )
@@ -142,22 +118,16 @@ class TigrisClientTest(TestCase):
 
     def test_get_db(self, ready_future):
         ready_future.return_value = self.done_future
-        client = TigrisClient(
-            ClientConfig(project_name="p1", server_url="localhost:5000")
-        )
+        client = TigrisClient(ClientConfig(project="p1", server_url="localhost:5000"))
         self.assertEqual(client.config.branch, client.get_db().branch)
-        self.assertEqual(client.config.project_name, client.get_db().project)
+        self.assertEqual(client.config.project, client.get_db().project)
 
     def test_get_search(self, ready_future):
         ready_future.return_value = self.done_future
-        client = TigrisClient(
-            ClientConfig(project_name="p1", server_url="localhost:5000")
-        )
-        self.assertEqual(client.config.project_name, client.get_search().project)
+        client = TigrisClient(ClientConfig(project="p1", server_url="localhost:5000"))
+        self.assertEqual(client.config.project, client.get_search().project)
 
     def test_get_vector_search(self, ready_future):
         ready_future.return_value = self.done_future
-        client = TigrisClient(
-            ClientConfig(project_name="p1", server_url="localhost:5000")
-        )
+        client = TigrisClient(ClientConfig(project="p1", server_url="localhost:5000"))
         self.assertEqual("v1", client.get_vector_store("v1").name)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -13,29 +13,71 @@ class TigrisClientTest(TestCase):
     def setUp(self) -> None:
         self.done_future = MagicMock(grpc.Future)
 
-    def test_without_config(self, ready_future):
+    def test_init_with_none(self, ready_future):
         ready_future.return_value = self.done_future
-        client = TigrisClient()
-        self.assertEqual("localhost:8081", client.config.server_url)
-        self.assertIsNone(client.config.client_id)
-        self.assertIsNone(client.config.client_secret)
-        self.assertIsNone(client.config.project_name)
-        self.assertEqual("", client.config.branch)
+        with self.assertRaisesRegex(
+            ValueError, "`TIGRIS_PROJECT` environment variable"
+        ):
+            TigrisClient()
+
+    def test_init_with_complete_dict(self, ready_future):
+        ready_future.return_value = self.done_future
+        client = TigrisClient(
+            {
+                "server_url": "uri",
+                "project": "project",
+                "client_id": "client",
+                "client_secret": "secret",
+                "branch": "branch",
+            }
+        )
+        self.assertEqual("uri:443", client.config.server_url)
+        self.assertEqual("client", client.config.client_id)
+        self.assertEqual("secret", client.config.client_secret)
+        self.assertEqual("project", client.config.project_name)
+        self.assertEqual("branch", client.config.branch)
+
+    def test_init_with_dict_missing_client_id(self, ready_future):
+        ready_future.return_value = self.done_future
+        with self.assertRaisesRegex(
+            ValueError, "`TIGRIS_CLIENT_ID` environment variable"
+        ):
+            TigrisClient(
+                {
+                    "project": "project",
+                    "client_secret": "secret",
+                }
+            )
+
+    def test_init_with_dict_missing_client_secret(self, ready_future):
+        ready_future.return_value = self.done_future
+        with self.assertRaisesRegex(
+            ValueError, "`TIGRIS_CLIENT_SECRET` environment variable"
+        ):
+            TigrisClient(
+                {
+                    "project": "project",
+                    "client_id": "id",
+                }
+            )
 
     @patch.dict(
         os.environ,
         {
-            "TIGRIS_URI": "uri_env",
+            "TIGRIS_URI": "localhost:5000",
             "TIGRIS_PROJECT": "project_env",
-            "TIGRIS_CLIENT_ID": "client_env",
-            "TIGRIS_CLIENT_SECRET": "secret_env",
-            "TIGRIS_DB_BRANCH": "branch_env",
         },
     )
-    def test_with_config(self, ready_future):
+    def test_init_with_partial_dict(self, ready_future):
+        ready_future.return_value = self.done_future
+        client = TigrisClient({"project": "p1"})
+        self.assertEqual("localhost:5000", client.config.server_url)
+        self.assertEqual("p1", client.config.project_name)
+
+    def test_init_with_config(self, ready_future):
         ready_future.return_value = self.done_future
         client = TigrisClient(
-            config=ClientConfig(
+            conf=ClientConfig(
                 server_url="test_url",
                 project_name="test_project",
                 client_id="test_client_id",
@@ -48,6 +90,21 @@ class TigrisClientTest(TestCase):
         self.assertEqual("test_client_secret", client.config.client_secret)
         self.assertEqual("test_project", client.config.project_name)
         self.assertEqual("test_branch", client.config.branch)
+
+    def test_init_local_dev(self, ready_future):
+        ready_future.return_value = self.done_future
+        client = TigrisClient(
+            {"server_url": "localhost:5000", "project": "test_project"}
+        )
+        self.assertEqual("localhost:5000", client.config.server_url)
+        self.assertEqual("test_project", client.config.project_name)
+
+    def test_init_failing_validation(self, ready_future):
+        ready_future.return_value = self.done_future
+        with self.assertRaisesRegex(
+            ValueError, "`TIGRIS_PROJECT` environment variable"
+        ):
+            TigrisClient({"server_url": "localhost:5000"})
 
     @patch.dict(
         os.environ,
@@ -70,18 +127,37 @@ class TigrisClientTest(TestCase):
 
     def test_strip_https(self, ready_future):
         ready_future.return_value = self.done_future
-        client = TigrisClient(config=ClientConfig(server_url="https://my.tigris.dev"))
+        conf = ClientConfig(
+            server_url="https://my.tigris.dev",
+            project_name="p1",
+            client_id="id",
+            client_secret="secret",
+        )
+        client = TigrisClient(conf)
         self.assertEqual("my.tigris.dev:443", client.config.server_url)
-        client = TigrisClient(config=ClientConfig(server_url="http://my.tigris.dev"))
+
+        conf.server_url = "http://my.tigris.dev"
+        client = TigrisClient(conf)
         self.assertEqual("my.tigris.dev:443", client.config.server_url)
 
     def test_get_db(self, ready_future):
         ready_future.return_value = self.done_future
-        client = TigrisClient()
+        client = TigrisClient(
+            ClientConfig(project_name="p1", server_url="localhost:5000")
+        )
         self.assertEqual(client.config.branch, client.get_db().branch)
         self.assertEqual(client.config.project_name, client.get_db().project)
 
     def test_get_search(self, ready_future):
         ready_future.return_value = self.done_future
-        client = TigrisClient()
+        client = TigrisClient(
+            ClientConfig(project_name="p1", server_url="localhost:5000")
+        )
         self.assertEqual(client.config.project_name, client.get_search().project)
+
+    def test_get_vector_search(self, ready_future):
+        ready_future.return_value = self.done_future
+        client = TigrisClient(
+            ClientConfig(project_name="p1", server_url="localhost:5000")
+        )
+        self.assertEqual("v1", client.get_vector_store("v1").name)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -8,9 +8,7 @@ from tigrisdb.types import ClientConfig
 @patch("api.generated.server.v1.search_pb2_grpc.SearchStub")
 class SearchTest(TestCase):
     def setUp(self) -> None:
-        self.client_config = ClientConfig(
-            server_url="localhost:5000", project_name="db1"
-        )
+        self.client_config = ClientConfig(server_url="localhost:5000", project="db1")
 
     def test_get_index(self, grpc_search):
         mock_grpc = grpc_search()
@@ -18,4 +16,4 @@ class SearchTest(TestCase):
         search_index = search.get_index("test-index")
 
         self.assertEqual("test-index", search_index.name)
-        self.assertEqual(self.client_config.project_name, search_index.project)
+        self.assertEqual(self.client_config.project, search_index.project)

--- a/tests/test_search_index.py
+++ b/tests/test_search_index.py
@@ -28,9 +28,7 @@ from tigrisdb.utils import marshal, unmarshal
 @patch("api.generated.server.v1.search_pb2_grpc.SearchStub")
 class SearchIndexTest(TestCase):
     def setUp(self) -> None:
-        self.client_config = ClientConfig(
-            server_url="localhost:5000", project_name="db1"
-        )
+        self.client_config = ClientConfig(server_url="localhost:5000", project="db1")
         self.index_name = "catalog"
 
     def test_search(self, grpc_search):

--- a/tests/test_types_client_config.py
+++ b/tests/test_types_client_config.py
@@ -11,11 +11,12 @@ class ClientConfigTest(TestCase):
 
     def test_init_with_none(self):
         conf = ClientConfig()
-        self.assertIsNone(conf.project_name)
+        self.assertIsNone(conf.project)
         self.assertEqual(conf.server_url, "api.preview.tigrisdata.cloud")
         self.assertIsNone(conf.client_id)
         self.assertIsNone(conf.client_secret)
         self.assertEqual(conf.branch, "")
+        self.assertFalse(conf.is_local_dev())
 
     @patch.dict(
         os.environ,
@@ -30,13 +31,13 @@ class ClientConfigTest(TestCase):
     def test_init_with_all_args(self):
         conf = ClientConfig(
             server_url="uri",
-            project_name="project",
+            project="project",
             client_id="client",
             client_secret="secret",
             branch="branch",
         )
         self.assertEqual(conf.server_url, "uri")
-        self.assertEqual(conf.project_name, "project")
+        self.assertEqual(conf.project, "project")
         self.assertEqual(conf.client_id, "client")
         self.assertEqual(conf.client_secret, "secret")
         self.assertEqual(conf.branch, "branch")
@@ -54,7 +55,7 @@ class ClientConfigTest(TestCase):
     def test_init_with_all_env(self):
         conf = ClientConfig()
         self.assertEqual(conf.server_url, "uri_env")
-        self.assertEqual(conf.project_name, "project_env")
+        self.assertEqual(conf.project, "project_env")
         self.assertEqual(conf.client_id, "client_env")
         self.assertEqual(conf.client_secret, "secret_env")
         self.assertEqual(conf.branch, "branch_env")
@@ -67,11 +68,55 @@ class ClientConfigTest(TestCase):
         },
     )
     def test_init_with_partial_env(self):
-        conf = ClientConfig(project_name="project")
-        self.assertEqual(conf.project_name, "project")
+        conf = ClientConfig(project="project")
+        self.assertEqual(conf.project, "project")
         self.assertEqual(conf.client_id, "client_env")
         self.assertIsNone(conf.client_secret)
         self.assertEqual(conf.branch, "branch_env")
+
+    @patch.dict(
+        os.environ,
+        {
+            "TIGRIS_URI": "uri_env",
+            "TIGRIS_PROJECT": "project_env",
+            "TIGRIS_CLIENT_ID": "client_env",
+            "TIGRIS_CLIENT_SECRET": "secret_env",
+            "TIGRIS_DB_BRANCH": "branch_env",
+        },
+    )
+    def test_merge_override_all(self):
+        conf = ClientConfig(
+            server_url="uri",
+            project="project",
+            client_id="client",
+            client_secret="secret",
+            branch="branch",
+        )
+        conf.merge(
+            project="project_dict",
+            client_id="client_dict",
+            client_secret="secret_dict",
+            server_url="uri_dict",
+            branch="branch_dict",
+        )
+        self.assertEqual(conf.server_url, "uri_dict")
+        self.assertEqual(conf.project, "project_dict")
+        self.assertEqual(conf.client_id, "client_dict")
+        self.assertEqual(conf.client_secret, "secret_dict")
+        self.assertEqual(conf.branch, "branch_dict")
+
+    def test_local_dev(self):
+        cases = [
+            (ClientConfig(), False),
+            (ClientConfig(server_url="localhost:1234"), True),
+            (ClientConfig(server_url="127.0.0.1"), True),
+            (ClientConfig(server_url="[::1]"), True),
+            (ClientConfig(server_url="https://tigrisdb-local-server:1234"), True),
+            (ClientConfig(server_url="https://api.tigris.cloud"), False),
+        ]
+        for conf, expected in cases:
+            with self.subTest(conf.server_url):
+                self.assertEqual(expected, conf.is_local_dev())
 
     def test_validate_without_project(self):
         conf = ClientConfig()
@@ -81,24 +126,20 @@ class ClientConfigTest(TestCase):
             conf.validate()
 
     def test_validate_without_client_id(self):
-        conf = ClientConfig(project_name="project")
-        conf.validate()
+        conf = ClientConfig(project="project")
         with self.assertRaisesRegex(
             ValueError, "`TIGRIS_CLIENT_ID` environment variable"
         ):
-            conf.validate(True)
+            conf.validate()
 
     def test_validate_without_client_secret(self):
-        conf = ClientConfig(project_name="project", client_id="id")
-        conf.validate()
+        conf = ClientConfig(project="project", client_id="id")
         with self.assertRaisesRegex(
             ValueError, "`TIGRIS_CLIENT_SECRET` environment variable"
         ):
-            conf.validate(True)
+            conf.validate()
 
     def test_validate_no_error(self):
-        conf = ClientConfig(
-            project_name="project", client_id="id", client_secret="secret"
-        )
+        conf = ClientConfig(project="project", client_id="id", client_secret="secret")
         conf.validate()
-        conf.validate(True)
+        self.assertFalse(conf.is_local_dev())

--- a/tests/test_types_client_config.py
+++ b/tests/test_types_client_config.py
@@ -1,0 +1,104 @@
+import os
+from unittest import TestCase
+from unittest.mock import patch
+
+from tigrisdb.types import ClientConfig
+
+
+class ClientConfigTest(TestCase):
+    def setUp(self) -> None:
+        pass
+
+    def test_init_with_none(self):
+        conf = ClientConfig()
+        self.assertIsNone(conf.project_name)
+        self.assertEqual(conf.server_url, "api.preview.tigrisdata.cloud")
+        self.assertIsNone(conf.client_id)
+        self.assertIsNone(conf.client_secret)
+        self.assertEqual(conf.branch, "")
+
+    @patch.dict(
+        os.environ,
+        {
+            "TIGRIS_URI": "uri_env",
+            "TIGRIS_PROJECT": "project_env",
+            "TIGRIS_CLIENT_ID": "client_env",
+            "TIGRIS_CLIENT_SECRET": "secret_env",
+            "TIGRIS_DB_BRANCH": "branch_env",
+        },
+    )
+    def test_init_with_all_args(self):
+        conf = ClientConfig(
+            server_url="uri",
+            project_name="project",
+            client_id="client",
+            client_secret="secret",
+            branch="branch",
+        )
+        self.assertEqual(conf.server_url, "uri")
+        self.assertEqual(conf.project_name, "project")
+        self.assertEqual(conf.client_id, "client")
+        self.assertEqual(conf.client_secret, "secret")
+        self.assertEqual(conf.branch, "branch")
+
+    @patch.dict(
+        os.environ,
+        {
+            "TIGRIS_URI": "uri_env",
+            "TIGRIS_PROJECT": "project_env",
+            "TIGRIS_CLIENT_ID": "client_env",
+            "TIGRIS_CLIENT_SECRET": "secret_env",
+            "TIGRIS_DB_BRANCH": "branch_env",
+        },
+    )
+    def test_init_with_all_env(self):
+        conf = ClientConfig()
+        self.assertEqual(conf.server_url, "uri_env")
+        self.assertEqual(conf.project_name, "project_env")
+        self.assertEqual(conf.client_id, "client_env")
+        self.assertEqual(conf.client_secret, "secret_env")
+        self.assertEqual(conf.branch, "branch_env")
+
+    @patch.dict(
+        os.environ,
+        {
+            "TIGRIS_CLIENT_ID": "client_env",
+            "TIGRIS_DB_BRANCH": "branch_env",
+        },
+    )
+    def test_init_with_partial_env(self):
+        conf = ClientConfig(project_name="project")
+        self.assertEqual(conf.project_name, "project")
+        self.assertEqual(conf.client_id, "client_env")
+        self.assertIsNone(conf.client_secret)
+        self.assertEqual(conf.branch, "branch_env")
+
+    def test_validate_without_project(self):
+        conf = ClientConfig()
+        with self.assertRaisesRegex(
+            ValueError, "`TIGRIS_PROJECT` environment variable"
+        ):
+            conf.validate()
+
+    def test_validate_without_client_id(self):
+        conf = ClientConfig(project_name="project")
+        conf.validate()
+        with self.assertRaisesRegex(
+            ValueError, "`TIGRIS_CLIENT_ID` environment variable"
+        ):
+            conf.validate(True)
+
+    def test_validate_without_client_secret(self):
+        conf = ClientConfig(project_name="project", client_id="id")
+        conf.validate()
+        with self.assertRaisesRegex(
+            ValueError, "`TIGRIS_CLIENT_SECRET` environment variable"
+        ):
+            conf.validate(True)
+
+    def test_validate_no_error(self):
+        conf = ClientConfig(
+            project_name="project", client_id="id", client_secret="secret"
+        )
+        conf.validate()
+        conf.validate(True)

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from unittest.mock import MagicMock, Mock, call, patch
+from unittest.mock import Mock, call
 
 from tests import NotFoundRpcError
 from tigrisdb.errors import TigrisServerError
@@ -28,12 +28,14 @@ class VectorStoreTest(TestCase):
     def setUp(self) -> None:
         self.mock_index = Mock(spec=SearchIndex)
         self.mock_client = Mock(spec=Search)
-        with patch("tigrisdb.client.TigrisClient.__new__") as mock_tigris:
-            instance = MagicMock()
-            mock_tigris.return_value = instance
-            instance.get_search.return_value = self.mock_client
-            self.mock_client.get_index.return_value = self.mock_index
-            self.store = VectorStore("my_vectors")
+        # with patch("tigrisdb.client.TigrisClient.__new__") as mock_tigris:
+        #     instance = MagicMock()
+        #     mock_tigris.return_value = instance
+        #     instance.get_search.return_value = self.mock_client
+        #     self.mock_client.get_index.return_value = self.mock_index
+        #     self.store = VectorStore("my_vectors")
+        self.mock_client.get_index.return_value = self.mock_index
+        self.store = VectorStore(self.mock_client, "my_vectors")
 
     def test_add_documents_when_index_not_found(self):
         # throw error on first call and succeed on second

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -28,12 +28,6 @@ class VectorStoreTest(TestCase):
     def setUp(self) -> None:
         self.mock_index = Mock(spec=SearchIndex)
         self.mock_client = Mock(spec=Search)
-        # with patch("tigrisdb.client.TigrisClient.__new__") as mock_tigris:
-        #     instance = MagicMock()
-        #     mock_tigris.return_value = instance
-        #     instance.get_search.return_value = self.mock_client
-        #     self.mock_client.get_index.return_value = self.mock_index
-        #     self.store = VectorStore("my_vectors")
         self.mock_client.get_index.return_value = self.mock_index
         self.store = VectorStore(self.mock_client, "my_vectors")
 

--- a/tigrisdb/__init__.py
+++ b/tigrisdb/__init__.py
@@ -1,0 +1,6 @@
+from client import TigrisClient  # noqa: F401
+from collection import Collection  # noqa: F401
+from database import Database  # noqa: F401
+from search import Search  # noqa: F401
+from search_index import SearchIndex  # noqa: F401
+from vector_store import VectorStore  # noqa: F401

--- a/tigrisdb/__init__.py
+++ b/tigrisdb/__init__.py
@@ -1,6 +1,6 @@
-from client import TigrisClient  # noqa: F401
-from collection import Collection  # noqa: F401
-from database import Database  # noqa: F401
-from search import Search  # noqa: F401
-from search_index import SearchIndex  # noqa: F401
-from vector_store import VectorStore  # noqa: F401
+from .client import TigrisClient  # noqa: F401
+from .collection import Collection  # noqa: F401
+from .database import Database  # noqa: F401
+from .search import Search  # noqa: F401
+from .search_index import SearchIndex  # noqa: F401
+from .vector_store import VectorStore  # noqa: F401

--- a/tigrisdb/__init__.py
+++ b/tigrisdb/__init__.py
@@ -1,6 +1,6 @@
-from .client import TigrisClient  # noqa: F401
-from .collection import Collection  # noqa: F401
-from .database import Database  # noqa: F401
-from .search import Search  # noqa: F401
-from .search_index import SearchIndex  # noqa: F401
-from .vector_store import VectorStore  # noqa: F401
+from tigrisdb.client import TigrisClient  # noqa: F401
+from tigrisdb.collection import Collection  # noqa: F401
+from tigrisdb.database import Database  # noqa: F401
+from tigrisdb.search import Search  # noqa: F401
+from tigrisdb.search_index import SearchIndex  # noqa: F401
+from tigrisdb.vector_store import VectorStore  # noqa: F401

--- a/tigrisdb/client.py
+++ b/tigrisdb/client.py
@@ -10,6 +10,7 @@ from tigrisdb.database import Database
 from tigrisdb.errors import TigrisException
 from tigrisdb.search import Search
 from tigrisdb.types import ClientConfig
+from tigrisdb.vector_store import VectorStore
 
 
 class TigrisClient(object):
@@ -19,6 +20,7 @@ class TigrisClient(object):
     __search_client: SearchStub
     __config: ClientConfig
 
+    # TODO: Change client config to be a dict
     def __init__(self, config: Optional[ClientConfig] = None):
         os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"
 
@@ -68,14 +70,19 @@ class TigrisClient(object):
             raise TigrisException(f"Connection timed out {config.server_url}")
 
         self.__tigris_client = TigrisStub(channel)
+        self._database = Database(self.__tigris_client, self.__config)
         self.__search_client = SearchStub(channel)
+        self._search = Search(self.__search_client, self.__config)
 
     @property
     def config(self):
         return self.__config
 
-    def get_db(self):
-        return Database(self.__tigris_client, self.__config)
+    def get_db(self) -> Database:
+        return self._database
 
-    def get_search(self):
-        return Search(self.__search_client, self.__config)
+    def get_search(self) -> Search:
+        return self._search
+
+    def get_vector_store(self, name: str) -> VectorStore:
+        return VectorStore(self._search, name)

--- a/tigrisdb/collection.py
+++ b/tigrisdb/collection.py
@@ -23,7 +23,7 @@ class Collection:
 
     @property
     def project(self):
-        return self.__config.project_name
+        return self.__config.project
 
     @property
     def branch(self):

--- a/tigrisdb/database.py
+++ b/tigrisdb/database.py
@@ -23,7 +23,7 @@ class Database:
 
     @property
     def project(self):
-        return self.__config.project_name
+        return self.__config.project
 
     @property
     def branch(self):

--- a/tigrisdb/search.py
+++ b/tigrisdb/search.py
@@ -23,7 +23,7 @@ class Search:
 
     @property
     def project(self):
-        return self.__config.project_name
+        return self.__config.project
 
     def create_or_update_index(self, name: str, schema: dict) -> SearchIndex:
         req = CreateOrUpdateIndexRequest(

--- a/tigrisdb/search_index.py
+++ b/tigrisdb/search_index.py
@@ -37,7 +37,7 @@ class SearchIndex:
 
     @property
     def project(self):
-        return self.__config.project_name
+        return self.__config.project
 
     @property
     def name(self):

--- a/tigrisdb/types/__init__.py
+++ b/tigrisdb/types/__init__.py
@@ -8,7 +8,7 @@ Document: Type[dict] = Dict
 
 @dataclass
 class ClientConfig:
-    project_name: str = ""
+    project: str = ""
     client_id: Optional[str] = None
     client_secret: Optional[str] = None
     branch: str = ""
@@ -18,19 +18,35 @@ class ClientConfig:
         self.server_url = self.server_url or os.getenv(
             "TIGRIS_URI", "api.preview.tigrisdata.cloud"
         )
-        self.project_name = self.project_name or os.getenv("TIGRIS_PROJECT")
+        self.project = self.project or os.getenv("TIGRIS_PROJECT")
         self.client_id = self.client_id or os.getenv("TIGRIS_CLIENT_ID")
         self.client_secret = self.client_secret or os.getenv("TIGRIS_CLIENT_SECRET")
         self.branch = self.branch or os.getenv("TIGRIS_DB_BRANCH", "")
 
-    def validate(self, with_creds=False):
-        if not self.project_name:
+    def merge(self, **kwargs):
+        self.project = kwargs.get("project", self.project)
+        self.server_url = kwargs.get("server_url", self.server_url)
+        self.client_id = kwargs.get("client_id", self.client_id)
+        self.client_secret = kwargs.get("client_secret", self.client_secret)
+        self.branch = kwargs.get("branch", self.branch)
+
+    def is_local_dev(self) -> bool:
+        return any(
+            map(
+                lambda k: k in self.server_url,
+                ["localhost", "127.0.0.1", "tigrisdb-local-server:", "[::1]"],
+            )
+        )
+
+    def validate(self):
+        is_remote = not self.is_local_dev()
+        if not self.project:
             raise ValueError("Failed to resolve `TIGRIS_PROJECT` environment variable")
-        if with_creds and not self.client_id:
+        if is_remote and not self.client_id:
             raise ValueError(
                 "Failed to resolve `TIGRIS_CLIENT_ID` environment variable"
             )
-        if with_creds and not self.client_secret:
+        if is_remote and not self.client_secret:
             raise ValueError(
                 "Failed to resolve `TIGRIS_CLIENT_SECRET` environment variable"
             )

--- a/tigrisdb/types/__init__.py
+++ b/tigrisdb/types/__init__.py
@@ -1,4 +1,5 @@
 import abc
+import os
 from dataclasses import dataclass
 from typing import Dict, Optional, Type
 
@@ -12,6 +13,27 @@ class ClientConfig:
     client_secret: Optional[str] = None
     branch: str = ""
     server_url: str = ""
+
+    def __post_init__(self):
+        self.server_url = self.server_url or os.getenv(
+            "TIGRIS_URI", "api.preview.tigrisdata.cloud"
+        )
+        self.project_name = self.project_name or os.getenv("TIGRIS_PROJECT")
+        self.client_id = self.client_id or os.getenv("TIGRIS_CLIENT_ID")
+        self.client_secret = self.client_secret or os.getenv("TIGRIS_CLIENT_SECRET")
+        self.branch = self.branch or os.getenv("TIGRIS_DB_BRANCH", "")
+
+    def validate(self, with_creds=False):
+        if not self.project_name:
+            raise ValueError("Failed to resolve `TIGRIS_PROJECT` environment variable")
+        if with_creds and not self.client_id:
+            raise ValueError(
+                "Failed to resolve `TIGRIS_CLIENT_ID` environment variable"
+            )
+        if with_creds and not self.client_secret:
+            raise ValueError(
+                "Failed to resolve `TIGRIS_CLIENT_SECRET` environment variable"
+            )
 
 
 class Serializable(abc.ABC):

--- a/tigrisdb/types/search.py
+++ b/tigrisdb/types/search.py
@@ -1,5 +1,5 @@
 from dataclasses import InitVar, dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Dict, List, Optional, Union
 
 from api.generated.server.v1.api_pb2 import FacetCount as ProtoFacetCount
@@ -22,7 +22,7 @@ from tigrisdb.errors import TigrisException
 from tigrisdb.types import Document, Serializable
 from tigrisdb.types.filters import Filter
 from tigrisdb.types.sort import Sort
-from tigrisdb.utils import marshal, unmarshal
+from tigrisdb.utils import datetime_from_proto_ts, marshal, unmarshal
 
 dataclass_default_proto_field = field(
     default=None, repr=False, compare=False, hash=False
@@ -142,9 +142,9 @@ class DocMeta:
     def __post_init__(self, _p: ProtoSearchHitMeta):
         if _p:
             if _p.HasField("created_at"):
-                self.created_at = _p.created_at.ToDatetime(tzinfo=timezone.utc)
+                self.created_at = datetime_from_proto_ts(_p.created_at)
             if _p.HasField("updated_at"):
-                self.updated_at = _p.updated_at.ToDatetime(tzinfo=timezone.utc)
+                self.updated_at = datetime_from_proto_ts(_p.updated_at)
             if _p.HasField("match"):
                 self.text_match = TextMatchInfo(_p=_p.match)
 

--- a/tigrisdb/utils.py
+++ b/tigrisdb/utils.py
@@ -3,6 +3,8 @@ import datetime
 import json
 from typing import Any, Union
 
+from google.protobuf.timestamp_pb2 import Timestamp as ProtoTimestamp
+
 
 class CustomJSONEncoder(json.JSONEncoder):
     def default(self, obj: Any) -> Any:
@@ -47,3 +49,11 @@ def obj_to_b64(doc: object) -> str:
 
 def schema_to_bytes(schema: dict) -> bytes:
     return marshal(schema)
+
+
+_UTC_ZERO = datetime.datetime.fromtimestamp(0, tz=datetime.timezone.utc)
+
+
+def datetime_from_proto_ts(p: ProtoTimestamp):
+    delta = datetime.timedelta(seconds=p.seconds, microseconds=p.nanos // 1000)
+    return _UTC_ZERO.astimezone(tz=datetime.timezone.utc) + delta

--- a/tigrisdb/vector_store.py
+++ b/tigrisdb/vector_store.py
@@ -2,17 +2,16 @@ from typing import List, Optional
 
 import grpc
 
-from tigrisdb.client import TigrisClient
 from tigrisdb.errors import TigrisServerError
-from tigrisdb.types import ClientConfig
+from tigrisdb.search import Search
 from tigrisdb.types.filters import Filter
 from tigrisdb.types.search import DocStatus, IndexedDoc, Query, Result, VectorField
 from tigrisdb.types.vector import Document, DocWithScore
 
 
 class VectorStore:
-    def __init__(self, name: str, config: Optional[ClientConfig] = None):
-        self.client = TigrisClient(config).get_search()
+    def __init__(self, client: Search, name: str):
+        self.client = client
         self._index_name = name
         self.index = self.client.get_index(name)
 


### PR DESCRIPTION
### Downgrade grpc and protobuf dependencies 
- A few of langchain deps have them tied to older versions of grpc
- We lose some automatic proto typings when downgrading from protobuf==4.23.* to protobuf==3.19.6

### Vectorstore available from client
- Similar to `get_db()` and `get_search()`
```python
client = TigrisClient()
client.get_vector_store("my_name")
```

### Optionally instantiate a client from dictionary
Three ways to create Tigris client:
**1. Env vars**

```shell
TIGRIS_URI=
TIGRIS_PROJECT=
TIGRIS_CLIENT_ID=
TIGRIS_CLIENT_SECRET=
TIGRIS_DB_BRANCH=
```

```python
loadEnv()
client = TigrisClient()
```

**2. ClientConfig (supports partial config)**
```python
client = TigrisClient(conf=ClientConfig(
            server_url="https://my.tigris.dev",
            project="p1",
            client_id="id",
            client_secret="secret",
            db_branch="main"
        ))
```

**3. Dictionary (supports partial config)**
```python
client = TigrisClient(
            {
                "server_url": "uri",
                "project": "project",
                "client_id": "client",
                "client_secret": "secret",
                "branch": "branch",
            }
        )
```
Instantiating with a partial config/dictionary will override respective environment variables